### PR TITLE
Fix typo in follow command confirmation prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.so
 *.dylib
 *.iml
+github-followers
 # Test binary, built with `go test -c`
 *.test
 
@@ -21,6 +22,7 @@
 # Go workspace file
 go.work
 go.work.sum
+go.sum
 
 # env file
 .env

--- a/internal/cli/follow.go
+++ b/internal/cli/follow.go
@@ -64,7 +64,7 @@ func followCommand() *cobra.Command {
 			}
 
 			if force == false {
-				fmt.Printf("\nYou are shure that you want to unfollow %d users?", len(toFollow))
+				fmt.Printf("\nYou are sure that you want to follow %d users? (y/n):", len(toFollow))
 				confirm := helper.GetInput("")
 				if strings.ToLower(confirm) != "y" && strings.ToLower(confirm) != "yes" {
 					fmt.Println("Operation canceled")


### PR DESCRIPTION
- Changed 'shure' to 'sure' in the confirmation message
- Added '(y/n):' to make the expected input clearer

Update .gitignore to exclude build artifacts

- Added 'github-followers' binary to ignore list
- Added 'go.sum' to ignore list (though typically tracked, user preference)